### PR TITLE
Decouple trains from driving stand

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -16,14 +16,12 @@ advtrains.register_wagon("engine_zugspitzbahn", {
 			name=S("Driver Stand (front)"),
             attach_offset={x=o, y=6, z=8},
 			view_offset={x=0, y=-3, z=0},
-			driving_ctrl_access=true,
 			group = "dstand",
 		},
 		{
 			name=S("Driver Stand (back)"),
 			  attach_offset={x=o, y=-6, z=8},
 			view_offset={x=0, y=-3, z=0},
-			driving_ctrl_access=true,
 			group = "dstand",
 		},
 	},
@@ -31,6 +29,7 @@ advtrains.register_wagon("engine_zugspitzbahn", {
 		dstand={
 			name = "Driver Stand",
 			access_to = {},
+			driving_ctrl_access=true,
 		},
 	},
     assign_to_seat_group = {"dstand"},


### PR DESCRIPTION
Hi mbb
Here's the fix for the problem you mentioned in the forum.
In order to implement the bord computer, I had to move the driving_ctrl_access key into the "seat_groups" table.
I did the fix for the Zugspitzbahn. You need to do this on any of your other trains similarily: remove "driving_ctrl_access=true" from "seats" and add it into "seat_groups".
- orwell